### PR TITLE
missing color definitions

### DIFF
--- a/themes/Raleigh/gtk-3.0/gtk-dark.css
+++ b/themes/Raleigh/gtk-3.0/gtk-dark.css
@@ -5,6 +5,8 @@
 
 @define-color bg_color                                      @base_color;
 @define-color fg_color                                      #ffffff;
+@define-color theme_bg_color                                @bg_color;
+@define-color theme_fg_color                                @fg_color;
 
 @define-color selected_bg_color                             #49667f;
 @define-color selected_fg_color                             #ffffff;


### PR DESCRIPTION
this fixes alt-tab background being transparent on xfce